### PR TITLE
Remove duplicate line in onSignUp function

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -11,7 +11,6 @@ const hideButtons = function (event) {
 const onSignUp = function (event) {
   event.preventDefault()
   const data = getFormFields(this)
-  event.preventDefault()
   // console.log('sign up button clicked')
   api.signUp(data)
     .then(ui.signUpSuccess)


### PR DESCRIPTION
Remove event.preventDefault() as it was listed twice in the function.
Hope this resolves the issue consultants were experiencing when testing
the app.